### PR TITLE
Use seconds as time unit.

### DIFF
--- a/HawkNet.Tests/HawkFixture.cs
+++ b/HawkNet.Tests/HawkFixture.cs
@@ -127,7 +127,7 @@ namespace HawkNet.Tests
                     User = "steve"
                 };
 
-            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now) / 1000);
+            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now));
             var mac = Hawk.CalculateMac("example.com", "get", new Uri("http://example.com:8080/resource/4?filter=a"), "hello", ts.ToString(), "k3j4h2", credential, "header");
 
             var authorization = string.Format("id=\"456\", ts=\"{0}\", nonce=\"k3j4h2\", mac=\"{1}\", ext=\"hello\"",
@@ -150,7 +150,7 @@ namespace HawkNet.Tests
                 User = "steve"
             };
 
-            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now) / 1000);
+            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now));
             var mac = Hawk.CalculateMac("example.com", "get", new Uri("http://example.com:8080/resource/4?filter=a"), "hello", ts.ToString(), "k3j4h2", credential, "header");
 
             var authorization = string.Format("id=\"456\", ts=\"{0}\", nonce=\"k3j4h2\", mac=\"{1}\", ext=\"hello\"",
@@ -178,7 +178,7 @@ namespace HawkNet.Tests
             var payload = Encoding.UTF8.GetBytes("Thank you for flying Hawk");
             var hash = Convert.ToBase64String(hmac.ComputeHash(payload));
             
-            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now) / 1000);
+            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now));
             var mac = Hawk.CalculateMac("example.com", "get", new Uri("http://example.com:8080/resource/4?filter=a"), "hello", ts.ToString(), "k3j4h2", credential, "header", hash);
 
             var authorization = string.Format("id=\"456\", ts=\"{0}\", nonce=\"k3j4h2\", mac=\"{1}\", ext=\"hello\", hash=\"{2}\"",
@@ -202,7 +202,7 @@ namespace HawkNet.Tests
                 User = "steve"
             };
 
-            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now.Subtract(TimeSpan.FromDays(1))) / 1000);
+            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now.Subtract(TimeSpan.FromHours(1))));
             var mac = Hawk.CalculateMac("example.com", "get", new Uri("http://example.com:8080/resource/4?filter=a"), "hello", ts.ToString(), "k3j4h2", credential, "header");
 
             var authorization = string.Format("id=\"456\", ts=\"{0}\", nonce=\"k3j4h2\", mac=\"{1}\", ext=\"hello\"",
@@ -223,7 +223,7 @@ namespace HawkNet.Tests
                 User = "steve"
             };
 
-            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now.Add(TimeSpan.FromDays(1))) / 1000);
+            var ts = Math.Floor(Hawk.ConvertToUnixTimestamp(DateTime.Now.Add(TimeSpan.FromHours(1))));
             var mac = Hawk.CalculateMac("example.com", "get", new Uri("http://example.com:8080/resource/4?filter=a"), "hello", ts.ToString(), "k3j4h2", credential, "header");
 
             var authorization = string.Format("id=\"456\", ts=\"{0}\", nonce=\"k3j4h2\", mac=\"{1}\", ext=\"hello\"",

--- a/HawkNet.Tests/HttpWebRequestExtensionsTests.cs
+++ b/HawkNet.Tests/HttpWebRequestExtensionsTests.cs
@@ -24,7 +24,7 @@ namespace HawkNet.Tests
 
             var date = DateTime.Now;
 
-            var ts = (int)Math.Floor(Hawk.ConvertToUnixTimestamp(date) / 1000);
+            var ts = (int)Math.Floor(Hawk.ConvertToUnixTimestamp(date));
             var mac = Hawk.CalculateMac("example.com:8080", "get", new Uri("http://example.com:8080/resource/4?filter=a"), "hello", ts.ToString(), "k3j4h2", credential, "header");
 
             var authorization = string.Format("id=\"456\", ts=\"{0}\", nonce=\"k3j4h2\", mac=\"{1}\", ext=\"hello\"",

--- a/HawkNet/Hawk.cs
+++ b/HawkNet/Hawk.cs
@@ -215,7 +215,7 @@ namespace HawkNet
             }
 
             var normalizedTs = ((int)Math.Floor((ConvertToUnixTimestamp((ts.HasValue) 
-                ? ts.Value : DateTime.UtcNow) / 1000))).ToString();
+                ? ts.Value : DateTime.UtcNow)))).ToString();
 
             var mac = CalculateMac(host, 
                 method, 
@@ -251,7 +251,7 @@ namespace HawkNet
         {
             var now = ConvertToUnixTimestamp(DateTime.Now);
 
-            var expiration = Math.Floor(now / 1000) + ttlSec;
+            var expiration = Math.Floor(now) + ttlSec;
 
             var mac = CalculateMac(host, "GET", uri, ext, expiration.ToString(), "", credential, "bewit");
 
@@ -444,7 +444,7 @@ namespace HawkNet
         }
 
         /// <summary>
-        /// Converts a Datatime to an equivalent Unix Timestamp
+        /// Converts a Datatime to an equivalent Unix Timestamp, in seconds
         /// </summary>
         /// <param name="date"></param>
         /// <returns></returns>
@@ -463,7 +463,7 @@ namespace HawkNet
                 var now = ConvertToUnixTimestamp(DateTime.Now);
 
                 // Check timestamp staleness
-                if (Math.Abs((parsedTs * 1000) - now) > (timestampSkewSec * 1000))
+                if (Math.Abs(parsedTs - now) > timestampSkewSec)
                 {
                     return false;
                 }
@@ -569,7 +569,7 @@ namespace HawkNet
 
             var now = ConvertToUnixTimestamp(DateTime.Now);
 
-            if (expiration * 1000 <= now)
+            if (expiration <= now)
             {
                 throw new SecurityException("Access expired");
             }


### PR DESCRIPTION
Uses seconds as the internal time unit. Fixes issue #14.
