### PR TITLE
removed setting of host header to incomplete value (bad port on client)

### DIFF
--- a/HawkNet.WebApi/HawkClientMessageHandler.cs
+++ b/HawkNet.WebApi/HawkClientMessageHandler.cs
@@ -52,8 +52,6 @@ namespace HawkNet.WebApi
                     credential);
             }
 
-            request.Headers.Host = request.RequestUri.Host;
-
             request.SignRequest(credential,
                 this.ext,
                 this.ts,


### PR DESCRIPTION
The code that was setting the Host header was failing to include the port. This makes for different hashes between the client and server.