### PR TITLE
[HawkNet.OWIN] AuthenticationHeaderValue.Parse exception when IncludeServerAuthorization is true

### DIFF
--- a/HawkNet.Owin.Tests/HawkAuthenticationHandlerFixture.cs
+++ b/HawkNet.Owin.Tests/HawkAuthenticationHandlerFixture.cs
@@ -637,6 +637,166 @@ namespace HawkNet.Owin.Tests
         }
 
         [TestMethod]
+        public void ShouldNotThrowWhenIncludeServerAuthorizationIsTrueAndAuthorizationIsMissing()
+        {
+            var credential = new HawkCredential
+            {
+                Id = "123",
+                Algorithm = "sha256",
+                Key = "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn",
+                User = "steve"
+            };
+
+            var body = "hello world";
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+            var ms = new MemoryStream();
+            ms.Write(bodyBytes, 0, bodyBytes.Length);
+            ms.Flush();
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var logger = new Logger();
+            var builder = new AppBuilderFactory().Create();
+            builder.SetLoggerFactory(new LoggerFactory(logger));
+            var context = new OwinContext();
+            var request = (OwinRequest)context.Request;
+
+            request.Set<Action<Action<object>, object>>("server.OnSendingHeaders", RegisterForOnSendingHeaders);
+            request.Method = "post";
+            request.Body = ms;
+            request.SetHeader("Host", new string[] { "example.com" });
+            request.SetUri(new Uri("http://example.com:8080/resource/4?filter=a"));
+            request.ContentType = "text/plain";
+
+            var response = (OwinResponse)context.Response;
+
+            var middleware = new HawkAuthenticationMiddleware(
+                            new AppFuncTransition((env) =>
+                            {
+                                response.StatusCode = 200;
+                                return Task.FromResult<object>(null);
+                            }),
+                           builder,
+                           new HawkAuthenticationOptions
+                           {
+                               Credentials = (id) => Task.FromResult(credential),
+                               IncludeServerAuthorization = true
+                           }
+                        );
+
+            var task = middleware.Invoke(context);
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.AreEqual(null, task.Exception);
+        }
+
+        [TestMethod]
+        public void ShouldNotThrowWhenIncludeServerAuthorizationIsTrueAndAuthorizationIsOtherScheme()
+        {
+            var credential = new HawkCredential
+            {
+                Id = "123",
+                Algorithm = "sha256",
+                Key = "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn",
+                User = "steve"
+            };
+
+            var body = "hello world";
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+            var ms = new MemoryStream();
+            ms.Write(bodyBytes, 0, bodyBytes.Length);
+            ms.Flush();
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var logger = new Logger();
+            var builder = new AppBuilderFactory().Create();
+            builder.SetLoggerFactory(new LoggerFactory(logger));
+            var context = new OwinContext();
+            var request = (OwinRequest)context.Request;
+            request.SetHeader("Authorization", new[] { "OtherScheme" });
+
+            request.Set<Action<Action<object>, object>>("server.OnSendingHeaders", RegisterForOnSendingHeaders);
+            request.Method = "post";
+            request.Body = ms;
+            request.SetHeader("Host", new string[] { "example.com" });
+            request.SetUri(new Uri("http://example.com:8080/resource/4?filter=a"));
+            request.ContentType = "text/plain";
+
+            var response = (OwinResponse)context.Response;
+
+            var middleware = new HawkAuthenticationMiddleware(
+                            new AppFuncTransition((env) =>
+                            {
+                                response.StatusCode = 200;
+                                return Task.FromResult<object>(null);
+                            }),
+                           builder,
+                           new HawkAuthenticationOptions
+                           {
+                               Credentials = (id) => Task.FromResult(credential),
+                               IncludeServerAuthorization = true
+                           }
+                        );
+
+            var task = middleware.Invoke(context);
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.AreEqual(null, task.Exception);
+        }
+        [TestMethod]
+        public void ShouldNotThrowWhenIncludeServerAuthorizationIsTrueAndAuthorizationIsEmpty()
+        {
+            var credential = new HawkCredential
+            {
+                Id = "123",
+                Algorithm = "sha256",
+                Key = "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn",
+                User = "steve"
+            };
+
+            var body = "hello world";
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+            var ms = new MemoryStream();
+            ms.Write(bodyBytes, 0, bodyBytes.Length);
+            ms.Flush();
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var logger = new Logger();
+            var builder = new AppBuilderFactory().Create();
+            builder.SetLoggerFactory(new LoggerFactory(logger));
+            var context = new OwinContext();
+            var request = (OwinRequest)context.Request;
+            request.SetHeader("Authorization", new[] { "" });
+
+            request.Set<Action<Action<object>, object>>("server.OnSendingHeaders", RegisterForOnSendingHeaders);
+            request.Method = "post";
+            request.Body = ms;
+            request.SetHeader("Host", new string[] { "example.com" });
+            request.SetUri(new Uri("http://example.com:8080/resource/4?filter=a"));
+            request.ContentType = "text/plain";
+
+            var response = (OwinResponse)context.Response;
+
+            var middleware = new HawkAuthenticationMiddleware(
+                            new AppFuncTransition((env) =>
+                            {
+                                response.StatusCode = 200;
+                                return Task.FromResult<object>(null);
+                            }),
+                           builder,
+                           new HawkAuthenticationOptions
+                           {
+                               Credentials = (id) => Task.FromResult(credential),
+                               IncludeServerAuthorization = true
+                           }
+                        );
+
+            var task = middleware.Invoke(context);
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.AreEqual(null, task.Exception);
+        }
+
+        [TestMethod]
         public void ShouldAuthenticateServer()
         {
             var credential = new HawkCredential

--- a/HawkNet.Owin/HawkAuthenticationHandler.cs
+++ b/HawkNet.Owin/HawkAuthenticationHandler.cs
@@ -64,7 +64,7 @@ namespace HawkNet.Owin
 
             if (Request.Headers.ContainsKey("authorization"))
             {
-                authorization = AuthenticationHeaderValue.Parse(Request.Headers["authorization"]);
+                AuthenticationHeaderValue.TryParse(Request.Headers["authorization"], out authorization);
             }
 
              if (authorization != null &&
@@ -153,15 +153,18 @@ namespace HawkNet.Owin
             {
                 if (this.Options.IncludeServerAuthorization)
                 {
-                    var authorization = AuthenticationHeaderValue.Parse(Request.Headers["authorization"]);
-
-                    await AuthenticateResponse(authorization.Parameter,
-                            Request.Host.Value,
-                            Request.Method,
-                            Request.Uri,
-                            Response.ContentType,
-                            this.Options.Credentials,
-                            Response);
+                    AuthenticationHeaderValue authorization;
+                    if (AuthenticationHeaderValue.TryParse(Request.Headers["authorization"], out authorization)
+                        && authorization.Scheme.Equals(HawkAuthenticationOptions.Scheme, StringComparison.OrdinalIgnoreCase))
+                    {
+                        await AuthenticateResponse(authorization.Parameter,
+                                Request.Host.Value,
+                                Request.Method,
+                                Request.Uri,
+                                Response.ContentType,
+                                this.Options.Credentials,
+                                Response);
+                    }
                 }
             }
             else if (Response.StatusCode == 401)


### PR DESCRIPTION
Fixed an issue in HawkAuthenticationHandler with AuthenticationHeaderValue.Parse which would lead to an exception if IncludeServerAuthorization is set to true and client sends a value for Authorization which is empty, other scheme or missing altogether.
See [here](https://github.com/BrightSoul/HawkOwinAuthorizationParseError) this problem reproduced.

Switched to AuthenticationHeaderValue.TryParse and checked for scheme before calling AuthenticateResponse. Also added 3 unit test cases. 